### PR TITLE
Add express server middleware to allow Heroku to run app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: app/app.js
+web: server.js

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "angular": "^1.5.7",
+    "express": "^4.14.0",
     "foundation-sites": "^6.2.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,10 @@
+var express = require('express');
+var app = express();
+
+var port = process.env.PORT || 4000;
+
+app.listen(port, function() {
+    console.log('app listening on ' + port);
+});
+
+app.use(express.static('public'));


### PR DESCRIPTION
A middleware allowing for an environment variable $PORT needs to be added to allow for Heroku deployment.
